### PR TITLE
Add feature and JSON document flag to ignore persisting source to hub model

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ This will prompt you for a password to encrypt the private key. Each time you co
 Create your public key using the private key with the following command:
 
     openssl rsa -in  ~/.ssh/snowsql/rsa_key.p8 -pubout -out ~/.ssh/snowsql/rsa_key.pub
-    
+
 Attach the public key to the user by executing the below statement in Snowflake UI:
-    
+
     alter user <firstname.surname@infinityworks.com> set rsa_public_key='<THE_CONTENT_OF_YOUR_RSA_KEY.PUB>';
 
 #### Testing the connection

--- a/generate_raw_vault/app/export_hub_vault_models.py
+++ b/generate_raw_vault/app/export_hub_vault_models.py
@@ -30,8 +30,9 @@ def export_all_hub_files(metadata_file_dirs):
         substitutions = populate_hub_substitutions(
             hub_name, hub_substitutions, all_metadata
         )
-        formatted_hub_name = hub_name.lower()
-        write_model_files(substitutions, hub_template, "hub", formatted_hub_name)
+        if substitutions.get("source_list"):
+            formatted_hub_name = hub_name.lower()
+            write_model_files(substitutions, hub_template, "hub", formatted_hub_name)
 
 
 def populate_hub_substitutions(hub_name, hub_substitutions, all_metadata):
@@ -42,6 +43,11 @@ def populate_hub_substitutions(hub_name, hub_substitutions, all_metadata):
             natural_key_list = populate_hub_natural_key(
                 natural_key_list, metadata, hub_name
             )
+            discard_source_from_source_list = (
+                metadata.check_ignore_source_from_hub_model(hub_name)
+            )
+            if discard_source_from_source_list:
+                continue
             source_list = get_hub_source_list(metadata, source_list)
 
     hub_natural_key_set = set(create_set_from_list_of_lists(natural_key_list))

--- a/generate_raw_vault/app/metadata_handler.py
+++ b/generate_raw_vault/app/metadata_handler.py
@@ -44,6 +44,14 @@ class Metadata:
         list_business_topics = list(business_topics.keys())
         return list_business_topics
 
+    def check_ignore_source_from_hub_model(self, hub_name):
+        business_topics = self.get_business_topics()
+        hub_descriptors = business_topics.get(hub_name)
+        discard_source_from_hub_model = hub_descriptors.get(
+            "ignore_persisting_source_to_hub_model"
+        )
+        return discard_source_from_hub_model
+
     def get_hub_alias(self, hub):
         topics = self.get_business_topics()
         hub_alias = topics.get(hub).get("alias")

--- a/models/raw_vault/hubs/hub_customer.sql
+++ b/models/raw_vault/hubs/hub_customer.sql
@@ -4,8 +4,7 @@
   alias = "CUSTOMER"
   ) }}
 
-{%- set source_model = ["stg_customer_visits_v0_1_0",
-                        "stg_customers_v0_1_0",
+{%- set source_model = ["stg_customers_v0_1_0",
                         "stg_customers_v0_1_1",
                         "stg_transactions_v0_1_0"] -%}
 {%- set src_pk = "CUSTOMER_HK" -%}

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -36,7 +36,7 @@ sources:
       - name: TRANSACTIONS_V0_1_0
         columns:
           - name: CUSTOMER_ID
-            description: "Customer IDs are concatinations of their region code and registration number"
+            description: "Customer IDs are concatenations of their region code and registration number"
             tests:
               - unique
           - name: PRODUCT_ID

--- a/source_metadata/customer_visits_v0_1_0.json
+++ b/source_metadata/customer_visits_v0_1_0.json
@@ -7,6 +7,7 @@
   "destination_schema": "PUBLIC",
   "business_topics": {
     "CUSTOMER": {
+      "ignore_persisting_source_to_hub_model": true,
       "business_keys": {
         "CUST_ID": {
           "description": "CUSTOMER_VISITS_V1 Business key 1111",

--- a/source_metadata/customers_v0_1_0.json
+++ b/source_metadata/customers_v0_1_0.json
@@ -7,6 +7,7 @@
   "destination_schema": "PUBLIC",
   "business_topics": {
     "CUSTOMER": {
+      "ignore_persisting_source_to_hub_model": false,
       "business_keys": {
         "CUSTOMER_ID": {
           "description": "CUSTOMERS_V1 Business key 11111",

--- a/source_metadata/transactions_v0_1_0.json
+++ b/source_metadata/transactions_v0_1_0.json
@@ -7,9 +7,10 @@
   "destination_schema": "PUBLIC",
   "business_topics": {
     "CUSTOMER": {
+      "ignore_persisting_source_to_hub_model": false,
       "business_keys": {
         "CUSTOMER_ID": {
-          "description": "Customer IDs are concatinations of their region code and registration number",
+          "description": "Customer IDs are concatenations of their region code and registration number",
           "type": "STRING",
           "tests": {
             "unique": true
@@ -43,6 +44,7 @@
       ]
     },
     "TRANSACTION": {
+      "ignore_persisting_source_to_hub_model": false,
       "business_keys": {
         "DATE_OF_SESSION": {
           "description": "The datetime at which the order was made",


### PR DESCRIPTION
Add feature and JSON document flag to ignore persisting source to hub model. This is useful to reduce compute on the unions in hubs when you can guarantee a master list which includes all business keys for a given business topic (hub); the outcome is it will not be included in the source model list feeding the hub. Only use when this guarantee is true. If the flag is used in all instances of the business topic across the JSON metadata documents, no hub file will be created. 